### PR TITLE
Change the name of systemd link files to have "10" not "99" prefix

### DIFF
--- a/preserve_network_interface_naming.sh
+++ b/preserve_network_interface_naming.sh
@@ -45,7 +45,7 @@ filter_mac_addresses() {
 create_systemd_link_files() {
     local interface_names="$1"
     for interface_name in $interface_names; do
-        local link_file="/etc/systemd/network/99-$interface_name.link"
+        local link_file="/etc/systemd/network/10-$interface_name.link"
         local mac_address=$(ip -o link show "$interface_name" | awk '{print $(NF-2)}')
         cat << EOF > "$link_file"
 [Match]


### PR DESCRIPTION
The docs say it should be under 99, not at 99. (https://pve.proxmox.com/pve-docs/pve-admin-guide.html#network_override_device_names).

I chose 10 cos that's what the docs have.